### PR TITLE
Prerequisite version of Hamlib is now 4.7.1

### DIFF
--- a/README
+++ b/README
@@ -9,14 +9,14 @@ your receiver. It is also designed to provide database-driven tuning, memory
 and logging capabilities, based on FineWare's (discontinued) Smart Control
 series of receiver control packages for Windows. The Smart Gnome Control
 interface is written for Linux and Cygwin in GNU C/C++, using Glade, Gdk/Gtk+
-and curl. It also requires version 4.6 or later of Hamlib.
+and curl. It also requires version 4.7.1 or later of Hamlib.
 
 
 2. Compiling Smart Gnome Control
 
 To compile Smart Gnome Control you will need:
 
-* Hamlib 4.6
+* Hamlib 4.7.1
 * curl 8.11
 * Gtk+ 3.24
 * Gdk 3.24

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Smart Gnome Control began as an idea I had 21 years ago under Gnome v1.2. It was
 
 The following are required for Smart Gnome Control:
 
-* [Hamlib 4.6](https://github.com/Hamlib/Hamlib)
+* [Hamlib 4.7.1](https://github.com/Hamlib/Hamlib)
 * libcurl 7.60
 * Gtk+ 3.24
 * Gdk 3.24

--- a/configure.ac
+++ b/configure.ac
@@ -53,12 +53,12 @@ dnl AM_XGETTEXT_OPTION([--from-code=UTF-8])
 AC_CHECK_LIB([m], [sincos])
 
 dnl Check hamlib
-hamlib_modules="hamlib >= 4.6"
+hamlib_modules="hamlib >= 4.7.1"
 PKG_CHECK_MODULES(HAMLIB, [$hamlib_modules], [
   CFLAGS="$CFLAGS $HAMLIB_CFLAGS";
   LIBS="$LIBS $HAMLIB_LIBS";
 ], [
-  AC_MSG_ERROR([Hamradio control libraries 4.6 or later not found...])
+  AC_MSG_ERROR([Hamradio control libraries 4.7.1 or later not found...])
 ])
 
 dnl Check curl


### PR DESCRIPTION
This is to solve the compilation with usage of RIG_MODE_WFMS.